### PR TITLE
Fix typo Vision.md

### DIFF
--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -729,12 +729,12 @@ By adopting
 we can give developers _implicitly expressive_ test
 expectations. The expectation shown below, upon failure, can capture not just
 the boolean value `false`, but also the left-hand and right-hand operands and
-the operator itself (that is, `x`, `1`, and `>` respectively) and expand any
+the operator itself (that is, `x`, `1`, and `<` respectively) and expand any
 sub-expressions to their evaluated values, such as `x → 2`:
 
 ```swift
 let x = 2
-#expect(x > 1)  // failed: (x → 2) > 1
+#expect(x < 1)  // failed: (x → 2) > 1
 ```
 
 #### Handling optionals

--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -734,7 +734,7 @@ sub-expressions to their evaluated values, such as `x → 2`:
 
 ```swift
 let x = 2
-#expect(x < 1)  // failed: (x → 2) > 1
+#expect(x < 1)  // failed: (x → 2) < 1
 ```
 
 #### Handling optionals


### PR DESCRIPTION
The test passed because  `x` is greater than 1, as illustrated by the example in the vision document

### Motivation:

Failure case, but condition is a success

### Modifications:

Change comparison operator to less than

### Result:

Examples that match the description
